### PR TITLE
Some1and2 xc index repetition patch

### DIFF
--- a/Lindex/__init__.py
+++ b/Lindex/__init__.py
@@ -76,6 +76,3 @@ class lindex(dict):
 		except KeyError as e:
 			print(f"KeyError: {e}\nIgnoring Exception on `RTN`")
 
-f = lindex(StringIndexes=0)
-f.set(1, 2, 3, 4)
-f.pprint()

--- a/Lindex/__init__.py
+++ b/Lindex/__init__.py
@@ -1,50 +1,62 @@
 #!/usr/bin/env python3
 
 class lindex(dict):
+	def __init__(self, dictionary: dict = {}, StringIndexes: bool = False):
+		super().__init__(dictionary)
+		self.StringIndexes = StringIndexes
 
-	# Pretty Print Dictionary
+	# Pretty Prints Dictionary
 	def pprint(self, EmptyString: str = "    ") -> bool:
 		def PrintSubsection(dictionary: dict, EmptyString: str, SpaceAmnt: int = 0):
 			if type(dictionary) == type(self) or type(dictionary) == dict:
-				return "\n".join( EmptyString * SpaceAmnt + f"{entry}:\n" + PrintSubsection(dictionary[entry], EmptyString, SpaceAmnt + 1) for entry in dictionary )
+				return "\n".join( EmptyString * SpaceAmnt + f"{entry}: {type(entry)}\n" + PrintSubsection(dictionary[entry], EmptyString, SpaceAmnt + 1) for entry in dictionary )
 			else:
 				return EmptyString * SpaceAmnt + str(dictionary)
 		print(PrintSubsection(self, EmptyString))
 		return
 
-	# Add num to self[arg[0]][arg[1]][arg2]...
-	def add(self, *args, num: int = None) -> bool:
-		if num is None:
-			num = args[-1]
+	# Add `value` to self[arg[0]][arg[1]][arg2]...
+	def add(self, *args, value: int = None) -> bool:
+		if value is None:
+			value = args[-1]
 			args = args[:-1]
-		OldNum = self.RTN(*args)
-		if (type(OldNum) == int or type(OldNum) == float) and (type(num) == int or type(num) == float) :
-			self.set(*args, num = num + OldNum)
-			return
-		else:
-			assert False
-			return
+		OldValue = self.RTN(*args)
+		try:
+			self.set(*args, num = OldValue + value)
+			return True
+		except TypeError as e:
+			print(f"TypeError: {e}\nIgnoring Exception on `add`")
+			return False
 
-	# Sets self[arg[0]][arg[1]][arg2]... to num
-	def set(self, *args, num = None) -> bool:
-		if num is None:
-			num = args[-1]
+	# Sets self[arg[0]][arg[1]][arg2]... to value
+	def set(self, *args, value = None) -> bool:
+		if self.StringIndexes:
+			args = tuple(str(i) for i in args)
+		if value is None:
+			value = args[-1]
 			args = args[:-1]
 		def Carve(PointsDict: dict, Indexes: tuple, FinalState, States: list = []) -> list:
 			States.append(PointsDict)
 			if len(Indexes) == 0:
 				States[-1] = FinalState
 				return States
-			if Indexes[0] not in PointsDict:
-				PointsDict[Indexes[0]] = {}
+			try:
+				if Indexes[0] not in PointsDict.keys():
+					PointsDict[Indexes[0]] = {}
+			# If the index already exists as an entry, PointsDict will be set to the end value instead of a dictionary
+			# To prevent errors occuring because of this, the previous `if` statment uses the `.keys()` function to check for keys instead of just using `in` directly on the `PointsDict`
+			# The error then moves to become an `AttributeError` when a final value is being used as an index. 
+			except AttributeError:
+				PointsDict = {Indexes[0]: {}}
+				States[-1] = {States[-1]: {}}
 			return Carve(PointsDict[Indexes[0]], Indexes[1:], FinalState, States)
 
 		def Write(Indexes: tuple, States: list) -> dict:
 			for i in range(len(States) - 1):
 				States[-i-2][Indexes[-i-1]] = States[-i-1]
 			return States[0]
-		self = super().__init__(Write(args, Carve(self, args, num)))
-		return
+		self = super().__init__(Write(args, Carve(self, args, value)))
+		return True
 
 	# Returns self[arg[0]][arg[1]][arg2]...
 	def RTN(self, *args):
@@ -52,7 +64,18 @@ class lindex(dict):
 			if len(Indexes) == 0:
 				return dictionary
 			if Indexes[0] not in dictionary:
-				assert False
-				return
-			return Carve(dictionary[Indexes[0]], Indexes[1:])
-		return Carve(self, args)
+				raise KeyError(f"\"{Indexes[0]}\" is not a Valid Dictionary Key - {dictionary}[{Indexes[0]}]")
+			try:
+				return Carve(dictionary[Indexes[0]], Indexes[1:])
+			except TypeError as e: # This is only a type error because the dictionary is not being set to a dictionary, in reality the problem is with the `Keys` supplied
+				print(f"KeyError: `*path` Includes Final Value\nIgnoring Exception on `RTN`")
+		try:
+			if self.StringIndexes:
+				args = tuple(str(i) for i in args)
+			return Carve(self, args)
+		except KeyError as e:
+			print(f"KeyError: {e}\nIgnoring Exception on `RTN`")
+
+f = lindex(StringIndexes=0)
+f.set(1, 2, 3, 4)
+f.pprint()


### PR DESCRIPTION
# Fixed Repetition Bug

### This patch fixes a bug which is caused by setting an end value to a dictionary, an example of this would be
```python
d = lindex()
d.set(1, 2)
d.set(1, 2, 3)
```
### Before this would error and say you can't index a string by a string. This is now fixes and just sets `d` to `{1: {2: 3}}`